### PR TITLE
ci: update cargo files using exec plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,8 +183,8 @@ jobs:
           extra_plugins: |
             @semantic-release/changelog@6.0.3
             @semantic-release/git@10.0.1
+            @semantic-release/exec@6.0.3
             conventional-changelog-conventionalcommits@6.1.0
-            @semantic-release-cargo/semantic-release-cargo
 
   runehook-build-publish:
     runs-on: ubuntu-latest

--- a/.releaserc
+++ b/.releaserc
@@ -27,7 +27,12 @@
         "npmPublish": false
       }
     ],
-    "@semantic-release-cargo/semantic-release-cargo",
+    [
+      "@semantic-release/exec",
+      {
+        "prepareCmd": "sed -i -e '1h;2,$H;$!d;g' -e 's@name = \"runehook\"\\nversion = \"[^\"]*\"@name = \"runehook\"\\nversion = \"${nextRelease.version}\"@g' Cargo.toml Cargo.lock"
+      }
+    ],
     "@semantic-release/github",
     "@semantic-release/changelog",
     [


### PR DESCRIPTION
Uses the exec plugin to update the Cargo files instead of the `semantic-release-cargo` plugin.